### PR TITLE
Update to 1.11.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,10 @@ targetCompatibility='1.8'
 
 ext {
     massive = "0"
-    major = "11"
-    minor = "2"
-    mcVersion = "1.10.2"
-    forgeVersion = "12.18.1.2076"
+    major = "12"
+    minor = "0"
+    mcVersion = "1.11.2"
+    forgeVersion = "13.20.0.2304"
 }
 
 group= "uk.kihira.foxlib"
@@ -32,7 +32,7 @@ version = "${project.mcVersion}-${project.massive}.${project.major}.${project.mi
 minecraft {
     version = "${project.mcVersion}-${project.forgeVersion}"
     runDir = "run"
-    mappings = "snapshot_20160518"
+    mappings = "snapshot_20170522"
 
     replace '@VERSION@', project.version
 }

--- a/src/main/java/truetyper/FontHelper.java
+++ b/src/main/java/truetyper/FontHelper.java
@@ -2,6 +2,7 @@ package truetyper;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.vector.Matrix4f;
@@ -37,19 +38,19 @@ public class FontHelper {
         }
 
         FloatBuffer matrixData = BufferUtils.createFloatBuffer(16);
-        GL11.glGetFloat(GL11.GL_MODELVIEW_MATRIX, matrixData);
+        GlStateManager.getFloat(GL11.GL_MODELVIEW_MATRIX, matrixData);
         FontHelper.set2DMode(matrixData);
-        GL11.glPushMatrix();
+        GlStateManager.pushMatrix();
         y = mc.displayHeight-(y*sr.getScaleFactor())-(((font.getLineHeight()/amt)));
         float tx = (x*sr.getScaleFactor())+(font.getWidth(s)/2);
         float tranx = tx+2;
         float trany = y+(font.getLineHeight()/2);
-        GL11.glTranslatef(tranx,trany,0);
-        GL11.glRotatef(rotationZ, 0f, 0f, 1f);
-        GL11.glTranslatef(-tranx,-trany,0);
+        GlStateManager.translate(tranx,trany,0);
+        GlStateManager.rotate(rotationZ, 0f, 0f, 1f);
+        GlStateManager.translate(-tranx,-trany,0);
 
 
-        GL11.glEnable(GL11.GL_BLEND);
+        GlStateManager.enableBlend();
         if(s.contains(formatEscape)){
             String[] pars = s.split(formatEscape);
             float totalOffset = 0;
@@ -66,8 +67,8 @@ public class FontHelper {
         }else{
             font.drawString((x*sr.getScaleFactor()), y, s, scaleX/amt, scaleY/amt, rgba);
         }
-        GL11.glPopMatrix();
-        GL11.glDisable(GL11.GL_BLEND);
+        GlStateManager.popMatrix();
+        GlStateManager.disableBlend();
         FontHelper.set3DMode();
     }
 
@@ -75,27 +76,27 @@ public class FontHelper {
         Minecraft mc = Minecraft.getMinecraft();
         ScaledResolution sr = new ScaledResolution(mc);
         mc.entityRenderer.setupOverlayRendering();
-        GL11.glMatrixMode(GL11.GL_PROJECTION);
-        GL11.glPushMatrix();
-        //GL11.glLoadMatrix(matrixData);
+        GlStateManager.matrixMode(GL11.GL_PROJECTION);
+        GlStateManager.pushMatrix();
+        //GlStateManager.glLoadMatrix(matrixData);
 
-        GL11.glLoadIdentity();
-        GL11.glOrtho(0, mc.displayWidth, 0, mc.displayHeight, -1, 1);
-        GL11.glMatrixMode(GL11.GL_MODELVIEW);
-        GL11.glPushMatrix();
-        GL11.glLoadIdentity();
+        GlStateManager.loadIdentity();
+        GlStateManager.ortho(0, mc.displayWidth, 0, mc.displayHeight, -1, 1);
+        GlStateManager.matrixMode(GL11.GL_MODELVIEW);
+        GlStateManager.pushMatrix();
+        GlStateManager.loadIdentity();
 
         Matrix4f matrix = new Matrix4f();
         matrix.load(matrixData);
-        GL11.glTranslatef(matrix.m30*sr.getScaleFactor(),-matrix.m31*sr.getScaleFactor(), 0f);
+        GlStateManager.translate(matrix.m30*sr.getScaleFactor(),-matrix.m31*sr.getScaleFactor(), 0f);
 
     }
 
     private static void set3DMode() {
-        GL11.glMatrixMode(GL11.GL_MODELVIEW);
-        GL11.glPopMatrix();
-        GL11.glMatrixMode(GL11.GL_PROJECTION);
-        GL11.glPopMatrix();
+        GlStateManager.matrixMode(GL11.GL_MODELVIEW);
+        GlStateManager.popMatrix();
+        GlStateManager.matrixMode(GL11.GL_PROJECTION);
+        GlStateManager.popMatrix();
         Minecraft mc = Minecraft.getMinecraft();
         mc.entityRenderer.setupOverlayRendering();
     }

--- a/src/main/java/truetyper/TrueTypeFont.java
+++ b/src/main/java/truetyper/TrueTypeFont.java
@@ -1,5 +1,6 @@
 package truetyper;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.VertexBuffer;
 import org.lwjgl.BufferUtils;
@@ -231,20 +232,20 @@ public class TrueTypeFont {
 		//renderer.setColorRGBA_F(0f, 0f, 0f, 1f);
 
 		//renderer.addVertexWithUV(drawX, drawY, 0, TextureSrcX, TextureSrcY);
-		//GL11.glTexCoord2f(TextureSrcX, TextureSrcY);
-		//GL11.glVertex2f(drawX, drawY);
+		//GlStateManager.glTexCoord2f(TextureSrcX, TextureSrcY);
+		//GlStateManager.glVertex2f(drawX, drawY);
 
 		//renderer.addVertexWithUV(drawX, drawY + DrawHeight, 0, TextureSrcX, TextureSrcY + RenderHeight);
-		//GL11.glTexCoord2f(TextureSrcX, TextureSrcY + RenderHeight);
-		//GL11.glVertex2f(drawX, drawY + DrawHeight);
+		//GlStateManager.glTexCoord2f(TextureSrcX, TextureSrcY + RenderHeight);
+		//GlStateManager.glVertex2f(drawX, drawY + DrawHeight);
 
 		//renderer.addVertexWithUV(drawX + DrawWidth, drawY + DrawHeight, 0, TextureSrcX + RenderWidth, TextureSrcY + RenderHeight);
-		//GL11.glTexCoord2f(TextureSrcX + RenderWidth, TextureSrcY + RenderHeight);
-		//GL11.glVertex2f(drawX + DrawWidth, drawY + DrawHeight);
+		//GlStateManager.glTexCoord2f(TextureSrcX + RenderWidth, TextureSrcY + RenderHeight);
+		//GlStateManager.glVertex2f(drawX + DrawWidth, drawY + DrawHeight);
 
 		//renderer.addVertexWithUV(drawX + DrawWidth, drawY, 0, TextureSrcX + RenderWidth, TextureSrcY);
-		//GL11.glTexCoord2f(TextureSrcX + RenderWidth, TextureSrcY);
-		//GL11.glVertex2f(drawX + DrawWidth, drawY);
+		//GlStateManager.glTexCoord2f(TextureSrcX + RenderWidth, TextureSrcY);
+		//GlStateManager.glVertex2f(drawX + DrawWidth, drawY);
 	}
 
 	public float getWidth(String whatchars) {
@@ -296,8 +297,8 @@ public class TrueTypeFont {
 
 	public void drawString(float x, float y, String whatchars, int startIndex, int endIndex, float scaleX, float scaleY, int format, float... rgba) {
 		if(rgba.length == 0) rgba = new float[]{1f,1f,1f,1f};
-		GL11.glPushMatrix();
-		GL11.glScalef (scaleX, scaleY, 1.0f);
+		GlStateManager.pushMatrix();
+		GlStateManager.scale (scaleX, scaleY, 1.0f);
 
 		FloatObject floatObject = null;
 		int charCurrent;
@@ -341,10 +342,10 @@ public class TrueTypeFont {
 			}
 
 		}
-		GL11.glBindTexture(GL11.GL_TEXTURE_2D, fontTextureID);
+		GlStateManager.bindTexture(fontTextureID);
 		VertexBuffer renderer = Tessellator.getInstance().getBuffer();
 		//renderer.startDrawingQuads();
-	//	GL11.glBegin(GL11.GL_QUADS);
+	//	GlStateManager.glBegin(GlStateManager.GL_QUADS);
 		//if(rgba.length == 4) renderer.setColorRGBA_F(rgba[0], rgba[1], rgba[2], rgba[3]);
 		while (i >= startIndex && i <= endIndex) {
 
@@ -391,9 +392,9 @@ public class TrueTypeFont {
 			}
 		}
 		renderer.finishDrawing();
-	//	GL11.glEnd();
+	//	GlStateManager.glEnd();
 
-		GL11.glPopMatrix();
+		GlStateManager.popMatrix();
 	}
 	public static int loadImage(BufferedImage bufferedImage) {
 	    try {
@@ -431,27 +432,27 @@ public class TrueTypeFont {
 
 		    int internalFormat = GL11.GL_RGBA8,
 			format = GL11.GL_RGBA;
-			IntBuffer   textureId =  BufferUtils.createIntBuffer(1);
-			GL11.glGenTextures(textureId);
-			GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureId.get(0));
+//			IntBuffer   textureId =  BufferUtils.createIntBuffer(1);
+			int textureId = GlStateManager.generateTexture();
+			GlStateManager.bindTexture(textureId);
 
-			GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_CLAMP);
-			GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_CLAMP);
+			GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_S, GL11.GL_CLAMP);
+			GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_WRAP_T, GL11.GL_CLAMP);
 
 
-			GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
-			GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
-			//GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
-			//GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR_MIPMAP_NEAREST);
+			GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
+			GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
+			//GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR);
+			//GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR_MIPMAP_NEAREST);
 
-			//GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR_MIPMAP_LINEAR);
-			//GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST_MIPMAP_LINEAR);
-			//GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST_MIPMAP_NEAREST);
+			//GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_LINEAR_MIPMAP_LINEAR);
+			//GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST_MIPMAP_LINEAR);
+			//GlStateManager.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST_MIPMAP_NEAREST);
 
-			GL11.glTexEnvf(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE);
+			GlStateManager.glTexEnvf(GL11.GL_TEXTURE_ENV, GL11.GL_TEXTURE_ENV_MODE, GL11.GL_MODULATE);
 
 			GLU.gluBuild2DMipmaps(GL11.GL_TEXTURE_2D, internalFormat, width, height, format, GL11.GL_UNSIGNED_BYTE, byteBuffer);
-			return textureId.get(0);
+			return textureId;
 
 		} catch (Exception e) {
 	    	e.printStackTrace();
@@ -480,9 +481,7 @@ public class TrueTypeFont {
 	}
 
 	public void destroy() {
-		IntBuffer scratch = BufferUtils.createIntBuffer(1);
-		scratch.put(0, fontTextureID);
-		GL11.glBindTexture(GL11.GL_TEXTURE_2D, 0);
-		GL11.glDeleteTextures(scratch);
+		GlStateManager.bindTexture(0);
+		GlStateManager.deleteTexture(fontTextureID);
 	}
 }

--- a/src/main/java/uk/kihira/foxlib/client/gui/GuiBaseScreen.java
+++ b/src/main/java/uk/kihira/foxlib/client/gui/GuiBaseScreen.java
@@ -49,7 +49,7 @@ public abstract class GuiBaseScreen extends GuiScreen {
             this.maxTextWidth = maxTextWidth;
             if (tooltips != null && tooltips.length > 0) {
                 for (String s : tooltips) {
-                    tooltip.addAll(fontRendererObj.listFormattedStringToWidth(s, this.maxTextWidth));
+                    tooltip.addAll(fontRenderer.listFormattedStringToWidth(s, this.maxTextWidth));
                 }
             }
         }

--- a/src/main/java/uk/kihira/foxlib/client/gui/GuiIconButton.java
+++ b/src/main/java/uk/kihira/foxlib/client/gui/GuiIconButton.java
@@ -10,9 +10,9 @@ package uk.kihira.foxlib.client.gui;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.opengl.GL11;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,8 +34,8 @@ public class GuiIconButton extends GuiButton implements ITooltip {
     public void drawButton(Minecraft minecraft, int mouseX, int mouseY) {
         if (visible) {
             minecraft.getTextureManager().bindTexture(iconsTextures);
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-            GL11.glEnable(GL11.GL_BLEND);
+            GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+            GlStateManager.enableBlend();
             OpenGlHelper.glBlendFunc(770, 771, 1, 0);
 
             //Check mouse over
@@ -76,8 +76,8 @@ public class GuiIconButton extends GuiButton implements ITooltip {
         public void drawButton(Minecraft minecraft, int mouseX, int mouseY) {
             if (visible && toggled) {
                 minecraft.getTextureManager().bindTexture(iconsTextures);
-                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-                GL11.glEnable(GL11.GL_BLEND);
+                GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+                GlStateManager.enableBlend();
                 OpenGlHelper.glBlendFunc(770, 771, 1, 0);
                 //Check mouse over
                 hovered = mouseX >= xPosition && mouseY >= yPosition && mouseX < xPosition + width && mouseY < yPosition + height;

--- a/src/main/java/uk/kihira/foxlib/client/gui/GuiSlider.java
+++ b/src/main/java/uk/kihira/foxlib/client/gui/GuiSlider.java
@@ -27,7 +27,7 @@ public class GuiSlider extends GuiButton implements IControl<Float> {
         this.minValue = minValue;
         this.maxValue = maxValue;
         this.currentValue = defaultValue;
-        this.sliderValue = MathHelper.clamp_float((this.currentValue - this.minValue) / (this.maxValue - this.minValue), 0.0F, 1.0F);
+        this.sliderValue = MathHelper.clamp((this.currentValue - this.minValue) / (this.maxValue - this.minValue), 0.0F, 1.0F);
     }
 
     public GuiSlider(IControlCallback parent, int id, int x, int y, int width, float minValue, float maxValue, float defaultValue) {
@@ -78,7 +78,7 @@ public class GuiSlider extends GuiButton implements IControl<Float> {
     @Override
     public void setValue(Float currentValue) {
         this.currentValue = currentValue;
-        this.sliderValue = MathHelper.clamp_float((this.currentValue - this.minValue) / (this.maxValue - this.minValue), 0.0F, 1.0F);
+        this.sliderValue = MathHelper.clamp((this.currentValue - this.minValue) / (this.maxValue - this.minValue), 0.0F, 1.0F);
         this.displayString = String.valueOf(this.currentValue);
     }
 
@@ -90,7 +90,7 @@ public class GuiSlider extends GuiButton implements IControl<Float> {
     private void updateValues(int xPos, int yPos) {
         float prevValue = this.currentValue;
 
-        this.sliderValue = MathHelper.clamp_float((xPos - (this.xPosition + 4F)) / (this.width - 8F), 0F, 1F);
+        this.sliderValue = MathHelper.clamp((xPos - (this.xPosition + 4F)) / (this.width - 8F), 0F, 1F);
         this.currentValue = (int) (this.sliderValue * (this.maxValue - this.minValue) + this.minValue);
 
         if (this.parent != null && !this.parent.onValueChange(this, prevValue, this.currentValue)) {

--- a/src/main/java/uk/kihira/foxlib/client/toast/Toast.java
+++ b/src/main/java/uk/kihira/foxlib/client/toast/Toast.java
@@ -11,6 +11,7 @@ package uk.kihira.foxlib.client.toast;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraftforge.client.event.MouseEvent;
 import org.lwjgl.opengl.GL11;
@@ -34,23 +35,23 @@ public class Toast {
         this.width = width;
         this.time = time;
         this.message = Arrays.asList(message);
-        height = this.message.size() * Minecraft.getMinecraft().fontRendererObj.FONT_HEIGHT + 7;
+        height = this.message.size() * Minecraft.getMinecraft().fontRenderer.FONT_HEIGHT + 7;
     }
 
     public void onMouseEvent(MouseEvent mouseEvent) {}
 
     public void drawToast(int mouseX, int mouseY) {
         if (this.time > 0) {
-            FontRenderer fontRenderer = Minecraft.getMinecraft().fontRendererObj;
+            FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
             mouseOver = mouseX >= xPos && mouseY >= yPos && mouseX < xPos + width && mouseY < yPos + height;
             int opacity = mouseOver ? 255 : (int) (this.time * 256F / 10F);
             if (opacity > 255) opacity = 255;
             if (mouseOver) time = 20;
 
             if (opacity > 0) {
-                GL11.glPushMatrix();
-                GL11.glEnable(GL11.GL_BLEND);
-                GL11.glDisable(GL11.GL_LIGHTING);
+                GlStateManager.pushMatrix();
+                GlStateManager.enableBlend();
+                GlStateManager.disableLighting();
                 OpenGlHelper.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA, 1, 0);
                 drawBackdrop(xPos, yPos, width, height);
                 int colour = 0xFFFFFF | (opacity << 24);
@@ -58,9 +59,9 @@ public class Toast {
                     String s = message.get(i);
                     fontRenderer.drawStringWithShadow(s, (xPos + width / 2) - (fontRenderer.getStringWidth(s) / 2), yPos + 4 + (fontRenderer.FONT_HEIGHT * i), colour);
                 }
-                GL11.glDisable(GL11.GL_BLEND);
-                GL11.glColor4f(0F, 0F, 0F, 1F);
-                GL11.glPopMatrix();
+                GlStateManager.disableBlend();
+                GlStateManager.color(0F, 0F, 0F, 1F);
+                GlStateManager.popMatrix();
             }
         }
     }

--- a/src/main/java/uk/kihira/foxlib/client/toast/ToastManager.java
+++ b/src/main/java/uk/kihira/foxlib/client/toast/ToastManager.java
@@ -32,14 +32,14 @@ public class ToastManager {
     }
 
     public void createToast(int x, int y, String text) {
-        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRendererObj;
+        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
         int stringWidth = fontRenderer.getStringWidth(text);
         toasts.add(new Toast(x, y, stringWidth + 10,  stringWidth * 3, text));
     }
 
     @SuppressWarnings("unchecked")
     public void createCenteredToast(int x, int y, int maxWidth, String text) {
-        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRendererObj;
+        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
         int stringWidth = fontRenderer.getStringWidth(text);
         if (stringWidth > maxWidth) {
             List<String> strings = fontRenderer.listFormattedStringToWidth(text, maxWidth);

--- a/src/main/scala/uk/kihira/foxlib/client/ClientEventHandler.scala
+++ b/src/main/scala/uk/kihira/foxlib/client/ClientEventHandler.scala
@@ -10,48 +10,47 @@ package uk.kihira.foxlib.client
 
 import java.util
 
-import uk.kihira.foxlib.FoxLib
 import net.minecraft.block.state.IBlockState
 import net.minecraft.client.Minecraft
-import net.minecraft.client.renderer.{OpenGlHelper, RenderGlobal}
+import net.minecraft.client.renderer.{GlStateManager, OpenGlHelper, RenderGlobal}
 import net.minecraft.entity.player.EntityPlayer
 import net.minecraft.tileentity.TileEntity
 import net.minecraft.util.math.{AxisAlignedBB, RayTraceResult}
 import net.minecraftforge.client.event.DrawBlockHighlightEvent
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent
-import org.lwjgl.opengl.GL11
+import uk.kihira.foxlib.FoxLib
 
 object ClientEventHandler {
 
   @SubscribeEvent
   def onBlockHighlight(e: DrawBlockHighlightEvent) = {
     if (FoxLib.showCollisionBoxes && e.getTarget.typeOfHit == RayTraceResult.Type.BLOCK) {
-      val player: EntityPlayer = Minecraft.getMinecraft.thePlayer
-      val state: IBlockState = Minecraft.getMinecraft.theWorld.getBlockState(e.getTarget.getBlockPos)
+      val player: EntityPlayer = Minecraft.getMinecraft.player
+      val state: IBlockState = Minecraft.getMinecraft.world.getBlockState(e.getTarget.getBlockPos)
       val xOffset: Double = player.prevPosX + (player.posX - player.prevPosX) * e.getPartialTicks
       val yOffset: Double = player.prevPosY + (player.posY - player.prevPosY) * e.getPartialTicks
       val zOffset: Double = player.prevPosZ + (player.posZ - player.prevPosZ) * e.getPartialTicks
       val collisionBoxes: util.List[AxisAlignedBB] = new util.ArrayList[AxisAlignedBB]()
 
-      state.addCollisionBoxToList(Minecraft.getMinecraft.theWorld, e.getTarget.getBlockPos,
-        TileEntity.INFINITE_EXTENT_AABB, collisionBoxes, null)
+      state.addCollisionBoxToList(Minecraft.getMinecraft.world, e.getTarget.getBlockPos,
+        TileEntity.INFINITE_EXTENT_AABB, collisionBoxes, null, false)
 
       //Render the box(es)
-      GL11.glPushMatrix()
-      GL11.glEnable(GL11.GL_BLEND)
+      GlStateManager.pushMatrix()
+      GlStateManager.enableBlend()
       OpenGlHelper.glBlendFunc(770, 771, 1, 0)
-      GL11.glColor4f(0F, 0F, 0F, 0.4F)
-      GL11.glLineWidth(2F)
-      GL11.glDisable(GL11.GL_TEXTURE_2D)
-      GL11.glDepthMask(false)
+      GlStateManager.color(0F, 0F, 0F, 0.4F)
+      GlStateManager.glLineWidth(2F)
+      GlStateManager.disableTexture2D()
+      GlStateManager.depthMask(false)
       import scala.collection.JavaConversions._
       for (collisionBox <- collisionBoxes) {
-        RenderGlobal.func_189697_a(collisionBox.offset(-xOffset, -yOffset, -zOffset), 0.0F, 0.0F, 0.0F, 0.4F) //drawSelectionBoundingBox
+        RenderGlobal.drawSelectionBoundingBox(collisionBox.offset(-xOffset, -yOffset, -zOffset), 0.0F, 0.0F, 0.0F, 0.4F) //drawSelectionBoundingBox
       }
-      GL11.glDepthMask(true)
-      GL11.glEnable(GL11.GL_TEXTURE_2D)
-      GL11.glDisable(GL11.GL_BLEND)
-      GL11.glPopMatrix()
+      GlStateManager.depthMask(true)
+      GlStateManager.enableTexture2D()
+      GlStateManager.disableBlend()
+      GlStateManager.popMatrix()
 
       e.setCanceled(true)
     }

--- a/src/main/scala/uk/kihira/foxlib/client/TextHelper.scala
+++ b/src/main/scala/uk/kihira/foxlib/client/TextHelper.scala
@@ -11,9 +11,8 @@ package uk.kihira.foxlib.client
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.FontRenderer
 import net.minecraft.client.renderer.entity.RenderManager
-import net.minecraft.client.renderer.vertex.{DefaultVertexFormats}
-import net.minecraft.client.renderer.{OpenGlHelper, Tessellator, VertexBuffer}
-import org.lwjgl.opengl.GL11
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats
+import net.minecraft.client.renderer.{GlStateManager, OpenGlHelper, Tessellator, VertexBuffer}
 
 object TextHelper {
     /**
@@ -28,21 +27,21 @@ object TextHelper {
      * @param colour:[[Int]] The Minecraft version of colour
      */
     def drawWrappedMessageFacingPlayer(x:Double, y:Double, z:Double, scale:Float = 0.016666668F, maxWidth:Int, xOffset:Double, text:String, colour:Int = -1) {
-        val fontrenderer: FontRenderer = Minecraft.getMinecraft.fontRendererObj
+        val fontrenderer: FontRenderer = Minecraft.getMinecraft.fontRenderer
         val renderer: VertexBuffer = Tessellator.getInstance().getBuffer
         val renderManager: RenderManager = Minecraft.getMinecraft.getRenderManager
         val height: Double = fontrenderer.listFormattedStringToWidth(text, maxWidth).size * fontrenderer.FONT_HEIGHT
 
-        GL11.glPushMatrix()
-        GL11.glTranslated(x, y, z)
-        GL11.glNormal3f(0.0F, 1.0F, 0.0F)
-        GL11.glRotatef(-renderManager.playerViewY, 0.0F, 1.0F, 0.0F)
-        GL11.glRotatef(renderManager.playerViewX, 1.0F, 0.0F, 0.0F)
-        GL11.glScalef(-scale, -scale, scale)
-        GL11.glDisable(GL11.GL_LIGHTING)
-        GL11.glEnable(GL11.GL_BLEND)
+        GlStateManager.pushMatrix()
+        GlStateManager.translate(x, y, z)
+        GlStateManager.glNormal3f(0.0F, 1.0F, 0.0F)
+        GlStateManager.rotate(-renderManager.playerViewY, 0.0F, 1.0F, 0.0F)
+        GlStateManager.rotate(renderManager.playerViewX, 1.0F, 0.0F, 0.0F)
+        GlStateManager.scale(-scale, -scale, scale)
+        GlStateManager.disableLighting()
+        GlStateManager.enableBlend()
         OpenGlHelper.glBlendFunc(770, 771, 1, 0)
-        GL11.glDisable(GL11.GL_TEXTURE_2D)
+        GlStateManager.disableTexture2D()
 
         renderer.begin(7, DefaultVertexFormats.POSITION_COLOR)
         renderer.pos(xOffset - 1, -1, 0.0D).color(0f, 0f, 0f, 0.25f).endVertex()
@@ -51,14 +50,14 @@ object TextHelper {
         renderer.pos(xOffset + maxWidth + 1, -1, 0.0D).color(0f, 0f, 0f, 0.25f).endVertex()
         renderer.finishDrawing()
 
-        GL11.glEnable(GL11.GL_TEXTURE_2D)
-        GL11.glTranslatef(0F, 0F, -0.1F) //Move render forward a little to prevent flickering
+        GlStateManager.enableTexture2D()
+        GlStateManager.translate(0F, 0F, -0.1F) //Move render forward a little to prevent flickering
         fontrenderer.drawSplitString(text, xOffset.asInstanceOf[Int], 0, maxWidth, colour)
 
-        GL11.glEnable(GL11.GL_LIGHTING)
-        GL11.glDisable(GL11.GL_BLEND)
-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F)
-        GL11.glPopMatrix()
+        GlStateManager.enableLighting()
+        GlStateManager.disableBlend()
+        GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F)
+        GlStateManager.popMatrix()
     }
 
     /**
@@ -73,7 +72,7 @@ object TextHelper {
      * @param background:[[Boolean]] Whether to render the faint black background
      */
     def drawMultiLineMessageFacingPlayer(x:Double, y:Double, z:Double, scale:Float = 0.016666668F, text:Array[String], colour:Int = -1, center:Boolean = true, background:Boolean = true) {
-        val fontrenderer: FontRenderer = Minecraft.getMinecraft.fontRendererObj
+        val fontrenderer: FontRenderer = Minecraft.getMinecraft.fontRenderer
         val renderer: VertexBuffer = Tessellator.getInstance().getBuffer
         val renderManager: RenderManager = Minecraft.getMinecraft.getRenderManager
         val height: Double = text.size * fontrenderer.FONT_HEIGHT
@@ -86,17 +85,17 @@ object TextHelper {
             wid
         }
 
-        GL11.glPushMatrix()
-        GL11.glTranslated(x, y, z)
-        GL11.glNormal3f(0.0F, 1.0F, 0.0F)
-        GL11.glRotatef(-renderManager.playerViewY, 0.0F, 1.0F, 0.0F)
-        GL11.glRotatef(renderManager.playerViewX, 1.0F, 0.0F, 0.0F)
-        GL11.glScalef(-scale, -scale, scale)
-        GL11.glDisable(GL11.GL_LIGHTING)
-        GL11.glEnable(GL11.GL_BLEND)
-        GL11.glDisable(GL11.GL_CULL_FACE)
+        GlStateManager.pushMatrix()
+        GlStateManager.translate(x, y, z)
+        GlStateManager.glNormal3f(0.0F, 1.0F, 0.0F)
+        GlStateManager.rotate(-renderManager.playerViewY, 0.0F, 1.0F, 0.0F)
+        GlStateManager.rotate(renderManager.playerViewX, 1.0F, 0.0F, 0.0F)
+        GlStateManager.scale(-scale, -scale, scale)
+        GlStateManager.disableLighting()
+        GlStateManager.enableBlend()
+        GlStateManager.disableCull()
         OpenGlHelper.glBlendFunc(770, 771, 1, 0)
-        GL11.glDisable(GL11.GL_TEXTURE_2D)
+        GlStateManager.disableTexture2D()
 
         if (background) {
             renderer.begin(7, DefaultVertexFormats.POSITION_COLOR)
@@ -116,17 +115,17 @@ object TextHelper {
             renderer.finishDrawing()
         }
 
-        GL11.glEnable(GL11.GL_TEXTURE_2D)
-        GL11.glTranslatef(0F, 0F, -0.1F) //Move render forward a little to prevent flickering
+        GlStateManager.enableTexture2D()
+        GlStateManager.translate(0F, 0F, -0.1F) //Move render forward a little to prevent flickering
         for (line <- text) {
             if (center) fontrenderer.drawString(line, -fontrenderer.getStringWidth(line) / 2, 0, colour)
             else fontrenderer.drawString(line, 0, 0, colour)
-            GL11.glTranslatef(0F, -fontrenderer.FONT_HEIGHT, 0F)
+            GlStateManager.translate(0F, -fontrenderer.FONT_HEIGHT, 0F)
         }
 
-        GL11.glEnable(GL11.GL_CULL_FACE)
-        GL11.glDisable(GL11.GL_BLEND)
-        GL11.glColor4f(1F, 1F, 1F, 1F)
-        GL11.glPopMatrix()
+        GlStateManager.enableCull()
+        GlStateManager.disableBlend()
+        GlStateManager.color(1F, 1F, 1F, 1F)
+        GlStateManager.popMatrix()
     }
 }

--- a/src/main/scala/uk/kihira/foxlib/common/EntityHelper.scala
+++ b/src/main/scala/uk/kihira/foxlib/common/EntityHelper.scala
@@ -21,7 +21,7 @@ object EntityHelper {
     val xDiff: Double = targetX - sourceX
     val yDiff: Double = targetY - sourceY
     val zDiff: Double = targetZ - sourceZ
-    val d3: Double = MathHelper.sqrt_double((xDiff * xDiff) + (zDiff * zDiff)).asInstanceOf[Double]
+    val d3: Double = MathHelper.sqrt((xDiff * xDiff) + (zDiff * zDiff)).asInstanceOf[Double]
     val pitch: Float = (-(Math.atan2(yDiff, d3) * 180.0D / Math.PI)).asInstanceOf[Float]
     val yaw: Float = (Math.atan2(zDiff, xDiff) * 180.0D / Math.PI).asInstanceOf[Float] - 90.0F
 
@@ -30,7 +30,7 @@ object EntityHelper {
 
   def getPitchYawToEntity(sourceX:Double, sourceY:Double, sourceZ:Double, targetEntity:Entity): Array[Float] = {
     getPitchYawToPosition(sourceX, sourceY, sourceZ, targetEntity.posX - targetEntity.width, targetEntity.posY - targetEntity.height +
-      targetEntity.getEyeHeight.asInstanceOf[Double] + (if (targetEntity.worldObj.isRemote) 0.1F else 0.22F), targetEntity.posZ - targetEntity.width)
+      targetEntity.getEyeHeight.asInstanceOf[Double] + (if (targetEntity.world.isRemote) 0.1F else 0.22F), targetEntity.posZ - targetEntity.width)
   }
 
   def getPitchYawToEntity(sourceEntity:Entity, targetEntity:Entity): Array[Float] = {


### PR DESCRIPTION
This PR updates this lib for minecraft 1.11.2. It also replaces Gl11.<stuff> with GlStateManager if possible. This is recomended since minecraft 1.8.